### PR TITLE
add support for Emery

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
       "aplite",
       "basalt",
       "chalk",
-      "diorite"
+      "diorite",
+      "emery"
     ],
     "resources": {
       "media": []


### PR DESCRIPTION
now that the Pebble Time 2 is finally being realized (albeit 9 years later), it is time to add Emery to the list of supported platforms 🙂 